### PR TITLE
Fix the release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,5 @@ jobs:
         run: npm run dist
       - name: Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npm run release

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,7 @@
 # The Kerbside Lookup Widget
 Powered by [RecycleNow](https://recyclenow.com)
 
-[![Known Vulnerabilities](https://snyk.io/test/github/etchteam/kerbside-lookup/badge.svg)](https://snyk.io/test/github/etchteam/kerbside-lookup)
-[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=etchteam_kerbside-lookup)](https://sonarcloud.io/summary/new_code?id=etchteam_kerbside-lookup)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=etchteam_kerbside-lookup&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=etchteam_kerbside-lookup)
 
 Contact the [RecycleNow Digital Team](mailto:digitalteam@wrap.co.uk) for API Access.
 


### PR DESCRIPTION
Turns out semantic release uses a personal access token, not the github token.
